### PR TITLE
order sorted

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/DirectionResolver.java
+++ b/core/src/main/java/com/graphhopper/routing/DirectionResolver.java
@@ -102,7 +102,7 @@ public class DirectionResolver {
             // side are treated equally and for both cases we use the only possible edge ids.
             return DirectionResolverResult.restricted(inEdges.get(0).edgeId, outEdges.get(0).edgeId, inEdges.get(0).edgeId, outEdges.get(0).edgeId);
         } else if (adjacentEdges.nextPoints.size() == 2) {
-            Iterator<Point> iter = adjacentEdges.nextPoints.iterator();
+            Iterator<Point> iter = adjacentEdges.nextPoints.stream().sorted(Comparator.comparing(Point::toString)).iterator();
             Point p1 = iter.next();
             Point p2 = iter.next();
             List<Edge> in1 = adjacentEdges.getInEdges(p1);


### PR DESCRIPTION
This PR aims to fix the test:

```
com.graphhopper.routing.DirectionResolverOnQueryGraphTest.duplicateCoordinatesAtBaseOrAdjNode
```

**Module Name:** core

This inconsistency was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

The following command can be used to replicate the failures and validate the fix:

```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.graphhopper.routing.DirectionResolverOnQueryGraphTest#duplicateCoordinatesAtBaseOrAdjNode
```

**REASON**

The DirectionResolverOnQueryTest.duplicateCoordinatesAtBaseOrAdjNode() drips down to method checkResults() which checks to see if the both the direction lists(expectedresults and result of resolveddirections) are the same. 

https://github.com/Sujishark/graphhopper/blob/6b8d71667a5b05e3d4a29f8a316fce2df6c9e074/core/src/test/java/com/graphhopper/routing/DirectionResolverOnQueryGraphTest.java#L325-L328

But the method DirectionResolver.resolveDirections() didn't return the list deterministically that is not in the desired order. The adjacentedges are not iterated in a constant order and so a random order of directions is retrieved each of the time. 

**FIX**

Sorting this would be an ideal fix to avoid flaky tests.

https://github.com/Sujishark/graphhopper/blob/6b8d71667a5b05e3d4a29f8a316fce2df6c9e074/core/src/main/java/com/graphhopper/routing/DirectionResolver.java#L105


No user-facing change
No dependency upgrade

**Environment:**

> Java: openjdk version "11.0.20.1"
> Maven: Apache Maven 3.6.3