### PR TITLE
json order sorted

### DIFF
--- a/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java
+++ b/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java
@@ -18,14 +18,13 @@
 
 package com.graphhopper.jackson;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -46,7 +45,7 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout1.json")).toString(), objectMapper.valueToTree(il).toString());
+        assertEquals(jsonNodeToSortedMap(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout1.json"))).toString(), jsonNodeToSortedMap(objectMapper.valueToTree(il)).toString());
     }
 
 
@@ -65,7 +64,23 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout2.json")).toString(), objectMapper.valueToTree(il).toString());
+        assertEquals(jsonNodeToSortedMap(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout1.json"))).toString(), jsonNodeToSortedMap(objectMapper.valueToTree(il)).toString());
+    }
+
+    public static Map<String, JsonNode> jsonNodeToSortedMap(JsonNode jsonNode) {
+        Map<String, JsonNode> sortedMap = new TreeMap<>();
+
+        if (jsonNode.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
+
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                String key = entry.getKey();
+                JsonNode valueNode = entry.getValue();
+                sortedMap.put(key, valueNode);
+            }
+        }
+        return sortedMap;
     }
 
     private static Translation usTR = new Translation() {


### PR DESCRIPTION
This PR aims to fix 2 tests:

```
com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonIntegrity
com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonNaN
```

**Module Name:** web-api

This inconsistency was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

The following command can be used to replicate the failures and validate the fix:

```
mvn -pl web-api edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonIntegrity
```

**REASON**

The tests fail when the functions `testRoundaboutJsonIntegrity()` and `testRoundaboutJsonNaN()` verify the congruence of both the order of key-value pairs in a JSON object and the list returned from objectMapper. This occurs at:

https://github.com/Sujishark/graphhopper/blob/e53d88be858994591f3d28974d6a3c95f5fb9944/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java#L49

https://github.com/Sujishark/graphhopper/blob/e53d88be858994591f3d28974d6a3c95f5fb9944/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java#L68

However, since the JSON file's contents are returned in a random order, the comparison lacks determinism. 

**FIX**

To address this problem, one solution is to store the entire JSON object or list in a TreeMap to preserve its order.

https://github.com/Sujishark/graphhopper/blob/080df1da80d49c644c26d1a4c52b11c728ca08b0/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java#L48

No user-facing change
No dependency upgrade

**Environment:**

> Java: openjdk version "11.0.20.1"
> Maven: Apache Maven 3.6.3